### PR TITLE
Use flex on html tag to adjust height dynamically

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" class="flex dark">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -12,17 +12,13 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code&family=Inter:wght@300;400;700&display=swap">
 
     <style>
-      html {
-        height: -webkit-fill-available;
-      }
-
-      body, #app {
+      html, body, #app {
         height: 100vh;
         height: -webkit-fill-available;
       }
     </style>
   </head>
-  <body class="flex flex-col text-gray-900 dark:text-gray-400 bg-white dark:bg-gray-900">
+  <body class="flex flex-col flex-grow text-gray-900 dark:text-gray-400 bg-white dark:bg-gray-900">
     <noscript>
       <p>A hackable, offline-first markdown editor for notes, code snippets, and writing that runs entirely in-browser.</p>
       <p>JavaScript Required</p>


### PR DESCRIPTION
- closes #121

### Summary

The `html` container was not using flex, so the body tag was not being resized when the keyboard drawer was closed (related to `fill-available`).