### PR TITLE
Bugfix: Speech-to-text does not work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changes
+
+All notable changes are documented in this file.
+
+Our format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and we use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Staged](https://github.com/writewithocto/octo/compare/v0.20.3...main)
+
+These changes have not been released yet. Add a description of your changes to this file.
+
+### Bug Fixes
+
+- Fixed text duplication behavior with speech-to-text when creating a new doc.
+
+### Features
+
+- Added a new formatting toolbar to [Ink](https://github.com/writewithocto/ink).
+- Added a user setting for editor content width (in number of characters).
+- Added the ability to automatically match the system theme.
+
+### Maintenance
+
+- Upgraded Tailwind to v3
+
+## [v0.20.3](https://github.com/writewithocto/octo/compare/v0.20.2...v0.20.3)
+
+TBD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Here are a few resources to learn more about the process!
 - **Do not** comment on an Issue, Discussion, or Pull Request to engage in arguments or promote harassment. See our [Code of Conduct](https://github.com/writewithocto/octo/blob/main/CODE_OF_CONDUCT.md).
 - **Do not** disclose security vulnerabilities in public. Please email [david@octo.app](mailto:david@octo.app) instead.
 
-## Setting up the local dev environment
+## Set up the local dev environment
 
 Install the dependencies.
 
@@ -49,7 +49,7 @@ Copy `.env.example` to `.env`.
 cp .env.example .env
 ```
 
-### Launching the app
+### Launch the app
 
 Run the app in `development` mode.
 
@@ -67,9 +67,9 @@ _Note: Offline functionality is only available in `production` mode._
 yarn preview
 ```
 
-### Launching the Firebase Emulator
+### Launch the Firebase Emulator
 
-For more information about retrieving a Firebase access token, see the [docker-firebase-cli](https://github.com/voraciousdev/docker-firebase-cli) project.
+The emulator is not necessary for most changes. For more information about retrieving a Firebase access token, see the [docker-firebase-cli](https://github.com/voraciousdev/docker-firebase-cli) project.
 
 ```bash
 docker-compose up -d
@@ -77,11 +77,11 @@ docker-compose up -d
 
 The Firebase Emulator dashboard is available at [localhost:32777](http://localhost:32777).
 
-### Compiling the production build
+### Build the production app
 
 ```bash
 # compiles to ./dist
 yarn build
 ```
 
-The production build (static assets) will be available in the `dist` directory.
+The built files (static assets) will be available in the `dist` directory.

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -40,9 +40,9 @@ export default defineComponent({
   props: {
     appearance: {
       type: String,
-      default: () => ('dark'),
+      default: () => ('auto'),
       validator: (value) => (
-        ['dark', 'light'].includes(value)
+        ['auto', 'dark', 'light'].includes(value)
       ),
     },
     initialFocus: {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -152,9 +152,6 @@ export default defineComponent({
     },
   },
   methods: {
-    clearHistory() {
-      this.$refs.editable.instance.load(this.text)
-    },
     focusEditor() {
       this.$refs.editable.focus()
     },
@@ -184,12 +181,6 @@ export default defineComponent({
     },
     async input(text) {
       this.$emit('input', text)
-    },
-    async onReady(instance) {
-      this.editor = instance
-
-      this.focusInitial()
-      this.clearHistory()
     },
     async toggleMeta() {
       this.$store.dispatch(SET_RIGHT_SIDEBAR_VISIBILITY, !this.showRightSidebar)

--- a/src/components/TheContent.vue
+++ b/src/components/TheContent.vue
@@ -1,17 +1,33 @@
 <template>
   <SimpleBar class="the-content">
     <TheNavbar/>
-    <router-view :inheritAttrs="true" :key="$route.fullPath" class="flex"></router-view>
+    <router-view :inheritAttrs="true" :key="routeKey" class="flex"></router-view>
   </SimpleBar>
 </template>
 
 <script>
+import { nanoid } from 'nanoid'
 import TheNavbar from '/src/components/TheNavbar.vue'
 
 export default {
   name: 'TheContent',
   components: {
     TheNavbar,
+  },
+  data() {
+    return {
+      routeKey: null,
+    }
+  },
+  watch: {
+    $route: {
+      deep: true,
+      handler(route) {
+        if (route.params.preserve) { return }
+
+        this.routeKey = nanoid()
+      },
+    },
   },
 }
 </script>

--- a/src/store/modules/keybindings.js
+++ b/src/store/modules/keybindings.js
@@ -32,7 +32,7 @@ const makeListeners = (context) => {
     makeListener('c', () => goTo('context'), context),
     makeListener('d', () => goTo('discarded'), context),
     makeListener('e', () => goTo('graph'), context),
-    makeListener('n', () => goTo('dashboard'), context),
+    makeListener('n', () => goTo('new_doc'), context),
     makeListener('p', () => goTo('daily'), context),
     makeListener('r', () => goTo('recent'), context),
     makeListener('s', () => goTo('settings'), context),

--- a/src/views/Example.vue
+++ b/src/views/Example.vue
@@ -3,10 +3,10 @@
 </template>
 
 <script>
-import Editor from "/src/components/Editor.vue";
+import Editor from '/src/components/Editor.vue'
 
 export default {
-  name: "ExampleView",
+  name: 'ExampleView',
   components: {
     Editor,
   },
@@ -17,31 +17,25 @@ export default {
   },
   data() {
     return {
-      text: "",
-    };
+      text: '',
+    }
   },
   computed: {
     appearance() {
-      // return this.$store.state.settings.theme === "october" ? "dark" : this.$store.state.settings.theme;
+      if (this.$store.state.settings.theme === 'october') { return 'dark' }
 
-      if (this.$store.state.settings.theme === "light") { return "light"}
-      if (this.$store.state.settings.theme === "auto") {
-        const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches
-
-        return isDark ? "dark" : "light"
-    }
-        return "dark"
+      return this.$store.state.settings.theme
     },
     settings() {
-      return this.$store.state.settings.editor;
+      return this.$store.state.settings.editor
     },
   },
   async mounted() {
     fetch(this.url)
       .then((response) => response.text())
       .then((text) => {
-        this.text = text;
-      });
+        this.text = text
+      })
   },
-};
+}
 </script>


### PR DESCRIPTION
### Summary

Speech-to-text was not working, because creating a new doc caused the Editor view to refresh. The refresh was previously handled by retrieving/supplying the selection at the time of redirect, but that solution did not work for mobile speech-to-text. Instead, we will prevent the Editor view from refreshing when a doc is created.